### PR TITLE
docs: update team section heading in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -112,7 +112,7 @@
               a memorização. Progressão Personalizada: O aplicativo adapta-se ao
               ritmo e progresso de cada usuário.
             </p>
-            <h3>Membros da Equipe</h3>
+            <h3>Nossa Equipe:</h3>
             <ul>
                 <li><strong>Douglas Patriota</strong> - Desenvolvedor Mobile</li>
                 <li><strong>Erick Santos</strong> - Desenvolvedor Back End</li>


### PR DESCRIPTION
Changed the heading "Membros da Equipe" to "Nossa Equipe:" for better clarity and consistency in the language used on the page.